### PR TITLE
Bugfix/content block must not be empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .idea
 gradle.properties
+/.idea/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ allprojects {
 }
 
 dependencies {
-     implementation 'com.github.jakebreen:android-sendgrid:1.2.1'
+     implementation 'com.github.jakebreen:android-sendgrid:1.2.2'
 }
 ```
 

--- a/androidsendgrid/build.gradle
+++ b/androidsendgrid/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 1
-        versionName = "1.2.0"
+        versionCode 2
+        versionName = "1.2.2"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
@@ -14,10 +14,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-    }
-    compileOptions {
-        sourceCompatibility = '1.8'
-        targetCompatibility = '1.8'
     }
     testOptions {
         unitTests.returnDefaultValues = true

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridCall.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridCall.java
@@ -12,33 +12,36 @@ class SendGridCall {
 
     private static final String BASE_URL = "https://sendgrid.com/v3/";
 
-    Callable<SendGridResponse> call(String url, final String key, SendGridMailBody body) {
+    Callable<SendGridResponse> call(String url, final String key, final SendGridMailBody body) {
         final String apiUrl = String.format("%s%s", BASE_URL, url);
-        return () -> {
-            final URL url1 = new URL(apiUrl);
-            final HttpURLConnection urlConnection = (HttpURLConnection) url1.openConnection();
-            urlConnection.setDoOutput(true);
-            urlConnection.setRequestMethod("POST");
-            urlConnection.setRequestProperty("Authorization", key);
-            urlConnection.setRequestProperty("Accept", "application/json");
-            urlConnection.setRequestProperty("Content-Type", "application/json; utf-8");
+        return new Callable<SendGridResponse>() {
+            @Override
+            public SendGridResponse call() throws Exception {
+                final URL url1 = new URL(apiUrl);
+                final HttpURLConnection urlConnection = (HttpURLConnection) url1.openConnection();
+                urlConnection.setDoOutput(true);
+                urlConnection.setRequestMethod("POST");
+                urlConnection.setRequestProperty("Authorization", key);
+                urlConnection.setRequestProperty("Accept", "application/json");
+                urlConnection.setRequestProperty("Content-Type", "application/json; utf-8");
 
-            OutputStream outputStream = urlConnection.getOutputStream();
-            outputStream.write(body.getBody().toString().getBytes("UTF-8"));
-            outputStream.close();
+                OutputStream outputStream = urlConnection.getOutputStream();
+                outputStream.write(body.getBody().toString().getBytes("UTF-8"));
+                outputStream.close();
 
-            InputStream inputStream;
-            try {
-                inputStream = urlConnection.getInputStream();
-            } catch(IOException exception) {
-                inputStream = urlConnection.getErrorStream();
+                InputStream inputStream;
+                try {
+                    inputStream = urlConnection.getInputStream();
+                } catch (IOException exception) {
+                    inputStream = urlConnection.getErrorStream();
+                }
+
+                int code = urlConnection.getResponseCode();
+                String response = SendGridCall.this.readInputStream(inputStream);
+                urlConnection.disconnect();
+
+                return SendGridCall.this.createResponse(code, response);
             }
-
-            int code = urlConnection.getResponseCode();
-            String response = readInputStream(inputStream);
-            urlConnection.disconnect();
-
-            return createResponse(code, response);
         };
     }
 

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridCall.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridCall.java
@@ -40,7 +40,7 @@ class SendGridCall {
                 String response = SendGridCall.this.readInputStream(inputStream);
                 urlConnection.disconnect();
 
-                return SendGridCall.this.createResponse(code, response);
+                return createResponse(code, response);
             }
         };
     }

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMail.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMail.java
@@ -198,7 +198,7 @@ public class SendGridMail {
      *
      * @param enabled Indicates if this setting is enabled.
      */
-    public void setClickTrackingEnabled(@NonNull Boolean enabled) {
+    public void setClickTrackingEnabled(@NonNull final Boolean enabled) {
         trackingSettings.put(TRACKING_SETTING_CLICK_TRACKING, new HashMap<String, Boolean>() {{ put(TRACKING_SETTING_ENABLED, enabled); }});
     }
 
@@ -208,7 +208,7 @@ public class SendGridMail {
      *
      * @param enabled Indicates if this setting is enabled.
      */
-    public void setOpenTrackingEnabled(@NonNull Boolean enabled) {
+    public void setOpenTrackingEnabled(@NonNull final Boolean enabled) {
         trackingSettings.put(TRACKING_SETTING_OPEN_TRACKING, new HashMap<String, Boolean>() {{ put(TRACKING_SETTING_ENABLED, enabled); }});
     }
 
@@ -219,7 +219,7 @@ public class SendGridMail {
      *
      * @param enabled Indicates if this setting is enabled.
      */
-    public void setSubscriptionTrackingEnabled(@NonNull Boolean enabled) {
+    public void setSubscriptionTrackingEnabled(@NonNull final Boolean enabled) {
         trackingSettings.put(TRACKING_SETTING_SUBSCRIPTION_TRACKING, new HashMap<String, Boolean>() {{ put(TRACKING_SETTING_ENABLED, enabled); }});
     }
 

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
@@ -92,10 +92,14 @@ class SendGridMailBody {
         // If using a template the content block must be at least a single character
         // https://github.com/Jakebreen/android-sendgrid/issues/10
         if (contentMap.isEmpty()) {
-            final JSONObject jsonObject = new JSONObject();
-            jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_PLAIN);
-            jsonObject.put(PARAMS_CONTENT_VALUE, " ");
-            jsonArray.put(jsonObject);
+            final JSONObject jsonObjectPlain = new JSONObject();
+            jsonObjectPlain.put(PARAMS_CONTENT_TYPE, TYPE_PLAIN);
+            jsonObjectPlain.put(PARAMS_CONTENT_VALUE, " ");
+            jsonArray.put(jsonObjectPlain);
+            final JSONObject jsonObjectHtml = new JSONObject();
+            jsonObjectHtml.put(PARAMS_CONTENT_TYPE, TYPE_HTML);
+            jsonObjectHtml.put(PARAMS_CONTENT_VALUE, " ");
+            jsonArray.put(jsonObjectHtml);
             return jsonArray;
         }
 
@@ -105,6 +109,11 @@ class SendGridMailBody {
             jsonObject.put(PARAMS_CONTENT_VALUE, contentMap.get(TYPE_PLAIN));
             jsonArray.put(jsonObject);
             contentMap.remove(TYPE_PLAIN);
+        } else {
+            final JSONObject jsonObject = new JSONObject();
+            jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_PLAIN);
+            jsonObject.put(PARAMS_CONTENT_VALUE, " ");
+            jsonArray.put(jsonObject);
         }
 
         if (contentMap.containsKey(TYPE_HTML)) {
@@ -113,6 +122,11 @@ class SendGridMailBody {
             jsonObject.put(PARAMS_CONTENT_VALUE, contentMap.get(TYPE_HTML));
             jsonArray.put(jsonObject);
             contentMap.remove(TYPE_HTML);
+        } else {
+            final JSONObject jsonObject = new JSONObject();
+            jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_HTML);
+            jsonObject.put(PARAMS_CONTENT_VALUE, " ");
+            jsonArray.put(jsonObject);
         }
 
         for (Entry<String, String> set : contentMap.entrySet()) {

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
@@ -87,7 +87,18 @@ class SendGridMailBody {
 
     static JSONArray getContentParams(SendGridMail mail) throws JSONException {
         final JSONArray jsonArray = new JSONArray();
-        Map<String, String> contentMap = mail.getContent();
+        final Map<String, String> contentMap = mail.getContent();
+
+        // If using only a template the content block must at least a single character string
+        // https://github.com/Jakebreen/android-sendgrid/issues/10
+        if (contentMap.isEmpty()) {
+            final JSONObject jsonObject = new JSONObject();
+            jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_PLAIN);
+            jsonObject.put(PARAMS_CONTENT_VALUE, " ");
+            jsonArray.put(jsonObject);
+            return jsonArray;
+        }
+
         if (contentMap.containsKey(TYPE_PLAIN)) {
             final JSONObject jsonObject = new JSONObject();
             jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_PLAIN);
@@ -159,11 +170,8 @@ class SendGridMailBody {
     static JSONObject getTrackingSettings(SendGridMail mail) throws JSONException {
         final JSONObject jsonObject = new JSONObject();
         for (Entry<String, Map<String, Boolean>> set : mail.getTrackingSettings().entrySet()) {
-            System.out.println(set.getKey());
-            System.out.println(set.getValue());
             jsonObject.put(set.getKey(), set.getValue());
         }
-        System.out.println(jsonObject);
         return jsonObject;
     }
 

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
@@ -89,7 +89,7 @@ class SendGridMailBody {
         final JSONArray jsonArray = new JSONArray();
         final Map<String, String> contentMap = mail.getContent();
 
-        // If using only a template the content block must at least a single character string
+        // If using a template the content block must be at least a single character
         // https://github.com/Jakebreen/android-sendgrid/issues/10
         if (contentMap.isEmpty()) {
             final JSONObject jsonObject = new JSONObject();

--- a/androidsendgrid/src/test/java/uk/co/jakebreen/sendgridandroid/SendGridMailBodyTest.java
+++ b/androidsendgrid/src/test/java/uk/co/jakebreen/sendgridandroid/SendGridMailBodyTest.java
@@ -219,6 +219,19 @@ public class SendGridMailBodyTest {
         assertEquals(parseJsonFile("/json/email_dynamic_template"), create(mail).getBody().toString());
     }
 
+    @Test
+    public void givenDynamicTemplate_whenContentNotIncluded_thenReturnJsonBodyWithEmptyContentBlock() throws IOException {
+        final Map<String, String> toMap = new HashMap<>();
+        toMap.put("example@sendgrid.net", EMPTY);
+        when(mail.getRecipients()).thenReturn(toMap);
+
+        final Map<String, String> fromMap = new HashMap<>();
+        fromMap.put("john.doe@example.com", "John Doe");
+        when(mail.getFrom()).thenReturn(fromMap);
+
+        assertEquals(parseJsonFile("/json/email_content_empty"), create(mail).getBody().toString());
+    }
+
     private String parseJsonFile(String file) throws IOException {
         final InputStream inputStream = getClass().getResourceAsStream(file);
         final StringBuilder stringBuilder = new StringBuilder();

--- a/androidsendgrid/src/test/java/uk/co/jakebreen/sendgridandroid/SendGridMailBodyTest.java
+++ b/androidsendgrid/src/test/java/uk/co/jakebreen/sendgridandroid/SendGridMailBodyTest.java
@@ -86,11 +86,22 @@ public class SendGridMailBodyTest {
     }
 
     @Test
-    public void givenContent_whenCreatingMailBody_thenReturnJsonBody() throws JSONException {
-        final String expectedValue = "[{\"type\":\"text/plain\",\"value\":\"" + CONTENT_BODY + "\"}]";
+    public void givenPlainContent_whenCreatingMailBody_thenPlainContentAdded_andHtmlContentAddedAsEmpty() throws JSONException {
+        final String expectedValue = "[{\"type\":\"text/plain\",\"value\":\"" + CONTENT_BODY + "\"},{\"type\":\"text/html\",\"value\":\" \"}]";
 
         final Map<String, String> map = new HashMap<>();
         map.put(TYPE_PLAIN, CONTENT_BODY);
+        when(mail.getContent()).thenReturn(map);
+
+        assertEquals(expectedValue, getContentParams(mail).toString());
+    }
+
+    @Test
+    public void givenHtmlContent_whenCreatingMailBody_thenHtmlContentAdded_andPlainContentAddedAsEmpty() throws JSONException {
+        final String expectedValue = "[{\"type\":\"text/plain\",\"value\":\" \"},{\"type\":\"text/html\",\"value\":\"" + CONTENT_BODY + "\"}]";
+
+        final Map<String, String> map = new HashMap<>();
+        map.put(TYPE_HTML, CONTENT_BODY);
         when(mail.getContent()).thenReturn(map);
 
         assertEquals(expectedValue, getContentParams(mail).toString());
@@ -210,6 +221,7 @@ public class SendGridMailBodyTest {
 
         final Map<String, String> contentMap = new HashMap<>();
         contentMap.put(TYPE_PLAIN, CONTENT_BODY);
+        contentMap.put(TYPE_HTML, CONTENT_BODY);
         when(mail.getContent()).thenReturn(contentMap);
 
         final Map<String, String> fromMap = new HashMap<>();
@@ -230,6 +242,40 @@ public class SendGridMailBodyTest {
         when(mail.getFrom()).thenReturn(fromMap);
 
         assertEquals(parseJsonFile("/json/email_content_empty"), create(mail).getBody().toString());
+    }
+
+    @Test
+    public void givenPlainContent_thenHtmlContentEmpty() throws IOException {
+        final Map<String, String> toMap = new HashMap<>();
+        toMap.put("example@sendgrid.net", EMPTY);
+        when(mail.getRecipients()).thenReturn(toMap);
+
+        final Map<String, String> fromMap = new HashMap<>();
+        fromMap.put("john.doe@example.com", "John Doe");
+        when(mail.getFrom()).thenReturn(fromMap);
+
+        final Map<String, String> contentMap = new HashMap<>();
+        contentMap.put(TYPE_PLAIN, CONTENT_BODY);
+        when(mail.getContent()).thenReturn(contentMap);
+
+        assertEquals(parseJsonFile("/json/email_content_html_empty"), create(mail).getBody().toString());
+    }
+
+    @Test
+    public void givenHtmlContent_thenPlainContentEmpty() throws IOException {
+        final Map<String, String> toMap = new HashMap<>();
+        toMap.put("example@sendgrid.net", EMPTY);
+        when(mail.getRecipients()).thenReturn(toMap);
+
+        final Map<String, String> fromMap = new HashMap<>();
+        fromMap.put("john.doe@example.com", "John Doe");
+        when(mail.getFrom()).thenReturn(fromMap);
+
+        final Map<String, String> contentMap = new HashMap<>();
+        contentMap.put(TYPE_HTML, CONTENT_BODY);
+        when(mail.getContent()).thenReturn(contentMap);
+
+        assertEquals(parseJsonFile("/json/email_content_plain_empty"), create(mail).getBody().toString());
     }
 
     private String parseJsonFile(String file) throws IOException {

--- a/androidsendgrid/src/test/res/json/email_content_empty
+++ b/androidsendgrid/src/test/res/json/email_content_empty
@@ -16,6 +16,10 @@
     {
       "type":"text/plain",
       "value":" "
+    },
+    {
+      "type":"text/html",
+      "value":" "
     }
   ]
 }

--- a/androidsendgrid/src/test/res/json/email_content_empty
+++ b/androidsendgrid/src/test/res/json/email_content_empty
@@ -1,0 +1,21 @@
+{
+  "personalizations":[
+    {
+      "to":[
+        {
+          "email":"example@sendgrid.net"
+        }
+      ]
+    }
+  ],
+  "from":{
+    "name":"John Doe",
+    "email":"john.doe@example.com"
+  },
+  "content":[
+    {
+      "type":"text/plain",
+      "value":" "
+    }
+  ]
+}

--- a/androidsendgrid/src/test/res/json/email_content_html_empty
+++ b/androidsendgrid/src/test/res/json/email_content_html_empty
@@ -1,12 +1,6 @@
 {
   "personalizations":[
     {
-      "dynamic_template_data":{
-        "forename":"Englebert",
-        "surname":"Humperdink",
-        "retired":true,
-        "age":85
-      },
       "to":[
         {
           "email":"example@sendgrid.net"
@@ -18,7 +12,6 @@
     "name":"John Doe",
     "email":"john.doe@example.com"
   },
-  "template_id":"733ba07f-ead1-41fc-933a-3976baa23716",
   "content":[
     {
       "type":"text/plain",
@@ -26,7 +19,7 @@
     },
     {
       "type":"text/html",
-      "value":"Email content body"
+      "value":" "
     }
   ]
 }

--- a/androidsendgrid/src/test/res/json/email_content_plain_empty
+++ b/androidsendgrid/src/test/res/json/email_content_plain_empty
@@ -1,12 +1,6 @@
 {
   "personalizations":[
     {
-      "dynamic_template_data":{
-        "forename":"Englebert",
-        "surname":"Humperdink",
-        "retired":true,
-        "age":85
-      },
       "to":[
         {
           "email":"example@sendgrid.net"
@@ -18,11 +12,10 @@
     "name":"John Doe",
     "email":"john.doe@example.com"
   },
-  "template_id":"733ba07f-ead1-41fc-933a-3976baa23716",
   "content":[
     {
       "type":"text/plain",
-      "value":"Email content body"
+      "value":" "
     },
     {
       "type":"text/html",

--- a/androidsendgrid/src/test/res/json/emails_tracking_settings_enabled
+++ b/androidsendgrid/src/test/res/json/emails_tracking_settings_enabled
@@ -29,5 +29,10 @@
     }
   },
   "from":{},
-  "content":[]
+  "content":[
+      {
+        "type":"text/plain",
+        "value":" "
+      }
+    ]
 }

--- a/androidsendgrid/src/test/res/json/emails_tracking_settings_enabled
+++ b/androidsendgrid/src/test/res/json/emails_tracking_settings_enabled
@@ -33,6 +33,10 @@
       {
         "type":"text/plain",
         "value":" "
+      },
+      {
+        "type":"text/html",
+        "value":" "
       }
     ]
 }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -19,10 +19,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility = '1.8'
-        targetCompatibility = '1.8'
-    }
 
 }
 

--- a/testapp/src/main/java/uk/co/jakebreen/sendgridandroid/testapp/MainActivity.java
+++ b/testapp/src/main/java/uk/co/jakebreen/sendgridandroid/testapp/MainActivity.java
@@ -41,8 +41,8 @@ public class MainActivity extends AppCompatActivity {
     private static final int REQUEST_CODE = 1;
 
     private Button btnSend, btnAddAttachment, btnClearAttachments;
-    private EditText etRecipientEmail, getEtRecipientName;
-    private EditText etSenderEmail, getEtSenderName;
+    private EditText etRecipientEmail, etRecipientName;
+    private EditText etSenderEmail, etSenderName;
     private EditText etSubject, etContent;
     private EditText etReplyToEmail, getEtReplyToName;
     private TextView tvAttachments;
@@ -66,9 +66,9 @@ public class MainActivity extends AppCompatActivity {
         btnSend = findViewById(R.id.btn_send);
         btnAddAttachment = findViewById(R.id.btn_attachment);
         etRecipientEmail = findViewById(R.id.et_recipient_email);
-        getEtRecipientName = findViewById(R.id.et_recipient_name);
+        etRecipientName = findViewById(R.id.et_recipient_name);
         etSenderEmail = findViewById(R.id.et_senders_email);
-        getEtSenderName = findViewById(R.id.et_senders_name);
+        etSenderName = findViewById(R.id.et_senders_name);
         etSubject = findViewById(R.id.et_subject);
         etContent = findViewById(R.id.et_content);
         etReplyToEmail = findViewById(R.id.et_reply_to_email);
@@ -81,11 +81,17 @@ public class MainActivity extends AppCompatActivity {
         btnClearAttachments.setOnClickListener(v -> clearAttachments());
 
         etRecipientEmail.setText(sharedPreferences.getString(PREFERENCE_RECIPIENT_EMAIL, ""));
-        getEtRecipientName.setText(sharedPreferences.getString(PREFERENCE_RECIPIENT_NAME, ""));
+        etRecipientName.setText(sharedPreferences.getString(PREFERENCE_RECIPIENT_NAME, ""));
         etSenderEmail.setText(sharedPreferences.getString(PREFERENCE_SENDER_EMAIL, ""));
-        getEtSenderName.setText(sharedPreferences.getString(PREFERENCE_SENDER_NAME, ""));
+        etSenderName.setText(sharedPreferences.getString(PREFERENCE_SENDER_NAME, ""));
         etSubject.setText(sharedPreferences.getString(PREFERENCE_SUBJECT, ""));
         etContent.setText(sharedPreferences.getString(PREFERENCE_CONTENT, ""));
+
+//        etSenderEmail.setText("android-sendgrid@testapp.com");
+//        etSenderName.setText("Test App");
+//        etRecipientName.setText("Recipient");
+//        etSubject.setText("Test App Subject");
+
         clearAttachments();
     }
 
@@ -106,15 +112,15 @@ public class MainActivity extends AppCompatActivity {
 
     private void sendMail() {
         final String recipientEmail = etRecipientEmail.getText().toString();
-        final String recipientName = getEtRecipientName.getText().toString();
+        final String recipientName = etRecipientName.getText().toString();
         final String senderEmail = etSenderEmail.getText().toString();
-        final String senderName = getEtSenderName.getText().toString();
+        final String senderName = etSenderName.getText().toString();
         final String subject = etSubject.getText().toString();
         final String content = etContent.getText().toString();
         final String replyToEmail = etReplyToEmail.getText().toString();
         final String replyToName = getEtReplyToName.getText().toString();
 
-        if (recipientEmail.isEmpty() || senderEmail.isEmpty() || subject.isEmpty() || content.isEmpty()) {
+        if (recipientEmail.isEmpty() || senderEmail.isEmpty() || subject.isEmpty()) {
             showMissingField();
             return;
         }
@@ -123,7 +129,8 @@ public class MainActivity extends AppCompatActivity {
         mail.addRecipient(recipientEmail, recipientName);
         mail.setFrom(senderEmail, senderName);
         mail.setSubject(subject);
-        mail.setContent(content);
+
+        if (!content.isEmpty()) mail.setContent(content);
 
         if (!replyToEmail.equals("")) {
             mail.setReplyTo(replyToEmail, replyToName);
@@ -209,9 +216,9 @@ public class MainActivity extends AppCompatActivity {
         final SharedPreferences.Editor editor = sharedPreferences.edit();
 
         editor.putString(PREFERENCE_RECIPIENT_EMAIL, etRecipientEmail.getText().toString());
-        editor.putString(PREFERENCE_RECIPIENT_NAME, getEtRecipientName.getText().toString());
+        editor.putString(PREFERENCE_RECIPIENT_NAME, etRecipientName.getText().toString());
         editor.putString(PREFERENCE_SENDER_EMAIL, etSenderEmail.getText().toString());
-        editor.putString(PREFERENCE_SENDER_NAME, getEtSenderName.getText().toString());
+        editor.putString(PREFERENCE_SENDER_NAME, etSenderName.getText().toString());
         editor.putString(PREFERENCE_SUBJECT, etSubject.getText().toString());
         editor.putString(PREFERENCE_CONTENT, etContent.getText().toString());
 

--- a/testapp/src/main/java/uk/co/jakebreen/sendgridandroid/testapp/MainActivity.java
+++ b/testapp/src/main/java/uk/co/jakebreen/sendgridandroid/testapp/MainActivity.java
@@ -12,6 +12,9 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -105,10 +108,10 @@ public class MainActivity extends AppCompatActivity {
         etSubject.setText(sharedPreferences.getString(PREFERENCE_SUBJECT, ""));
         etContent.setText(sharedPreferences.getString(PREFERENCE_CONTENT, ""));
 
-//        etSenderEmail.setText("android-sendgrid@testapp.com");
-//        etSenderName.setText("Test App");
-//        etRecipientName.setText("Recipient");
-//        etSubject.setText("Test App Subject");
+        etSenderEmail.setText("android-sendgrid@testapp.com");
+        etSenderName.setText("Test App");
+        etRecipientName.setText("Recipient");
+        etSubject.setText("Test App Subject");
 
         clearAttachments();
     }
@@ -166,9 +169,25 @@ public class MainActivity extends AppCompatActivity {
             e.printStackTrace();
         }
 
-        if (!TEMPLATE_ID.isEmpty()) mail.setTemplateId(TEMPLATE_ID);
+        if (!TEMPLATE_ID.isEmpty()) {
+            mail.setTemplateId(TEMPLATE_ID);
+//            try {
+//                mail.setDynamicTemplateData(getTemplatePayload());
+//            } catch (JSONException e) {
+//                e.printStackTrace();
+//            }
+        }
 
         send(mail);
+    }
+
+    private JSONObject getTemplatePayload() throws JSONException {
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("field_one", "Hello this is field one");
+        jsonObject.put("field_two", "Hello this is field two");
+        jsonObject.put("field_three", "Hello this is field three");
+        jsonObject.put("image_text", "Hello this is image text");
+        return jsonObject;
     }
 
     private void send(SendGridMail mail) {

--- a/testapp/src/main/res/layout/activity_main.xml
+++ b/testapp/src/main/res/layout/activity_main.xml
@@ -181,7 +181,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="32dp"
                 android:layout_marginEnd="16dp"
-                android:text="SEnd Email"
+                android:text="Send Email"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fix a bug where an empty content block would return a 400 response from the server when using a template.
Ensure that both plain and html text types are present in the mail body even when the user leaves them empty.