### PR TITLE
Bugfix/empty html content overriding plain text

### DIFF
--- a/androidsendgrid/.gitignore
+++ b/androidsendgrid/.gitignore
@@ -1,1 +1,2 @@
 /build
+.idea

--- a/androidsendgrid/build.gradle
+++ b/androidsendgrid/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 2
-        versionName = "1.2.2"
+        versionCode 3
+        versionName = "1.2.3"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
@@ -1,7 +1,5 @@
 package uk.co.jakebreen.sendgridandroid;
 
-import android.util.Log;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
+++ b/androidsendgrid/src/main/java/uk/co/jakebreen/sendgridandroid/SendGridMailBody.java
@@ -1,5 +1,7 @@
 package uk.co.jakebreen.sendgridandroid;
 
+import android.util.Log;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -109,11 +111,6 @@ class SendGridMailBody {
             jsonObject.put(PARAMS_CONTENT_VALUE, contentMap.get(TYPE_PLAIN));
             jsonArray.put(jsonObject);
             contentMap.remove(TYPE_PLAIN);
-        } else {
-            final JSONObject jsonObject = new JSONObject();
-            jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_PLAIN);
-            jsonObject.put(PARAMS_CONTENT_VALUE, " ");
-            jsonArray.put(jsonObject);
         }
 
         if (contentMap.containsKey(TYPE_HTML)) {
@@ -122,11 +119,6 @@ class SendGridMailBody {
             jsonObject.put(PARAMS_CONTENT_VALUE, contentMap.get(TYPE_HTML));
             jsonArray.put(jsonObject);
             contentMap.remove(TYPE_HTML);
-        } else {
-            final JSONObject jsonObject = new JSONObject();
-            jsonObject.put(PARAMS_CONTENT_TYPE, TYPE_HTML);
-            jsonObject.put(PARAMS_CONTENT_VALUE, " ");
-            jsonArray.put(jsonObject);
         }
 
         for (Entry<String, String> set : contentMap.entrySet()) {

--- a/androidsendgrid/src/test/java/uk/co/jakebreen/sendgridandroid/SendGridMailBodyTest.java
+++ b/androidsendgrid/src/test/java/uk/co/jakebreen/sendgridandroid/SendGridMailBodyTest.java
@@ -86,8 +86,8 @@ public class SendGridMailBodyTest {
     }
 
     @Test
-    public void givenPlainContent_whenCreatingMailBody_thenPlainContentAdded_andHtmlContentAddedAsEmpty() throws JSONException {
-        final String expectedValue = "[{\"type\":\"text/plain\",\"value\":\"" + CONTENT_BODY + "\"},{\"type\":\"text/html\",\"value\":\" \"}]";
+    public void givenPlainContent_whenCreatingMailBody_thenPlainContentAdded_andNoHtmlContent() throws JSONException {
+        final String expectedValue = "[{\"type\":\"text/plain\",\"value\":\"" + CONTENT_BODY + "\"}]";
 
         final Map<String, String> map = new HashMap<>();
         map.put(TYPE_PLAIN, CONTENT_BODY);
@@ -97,8 +97,8 @@ public class SendGridMailBodyTest {
     }
 
     @Test
-    public void givenHtmlContent_whenCreatingMailBody_thenHtmlContentAdded_andPlainContentAddedAsEmpty() throws JSONException {
-        final String expectedValue = "[{\"type\":\"text/plain\",\"value\":\" \"},{\"type\":\"text/html\",\"value\":\"" + CONTENT_BODY + "\"}]";
+    public void givenHtmlContent_whenCreatingMailBody_thenHtmlContentAdded_andNoPlainContent() throws JSONException {
+        final String expectedValue = "[{\"type\":\"text/html\",\"value\":\"" + CONTENT_BODY + "\"}]";
 
         final Map<String, String> map = new HashMap<>();
         map.put(TYPE_HTML, CONTENT_BODY);
@@ -245,7 +245,7 @@ public class SendGridMailBodyTest {
     }
 
     @Test
-    public void givenPlainContent_thenHtmlContentEmpty() throws IOException {
+    public void givenPlainContent_thenNoHtmlContent() throws IOException {
         final Map<String, String> toMap = new HashMap<>();
         toMap.put("example@sendgrid.net", EMPTY);
         when(mail.getRecipients()).thenReturn(toMap);
@@ -262,7 +262,7 @@ public class SendGridMailBodyTest {
     }
 
     @Test
-    public void givenHtmlContent_thenPlainContentEmpty() throws IOException {
+    public void givenHtmlContent_thenNoPlainContent() throws IOException {
         final Map<String, String> toMap = new HashMap<>();
         toMap.put("example@sendgrid.net", EMPTY);
         when(mail.getRecipients()).thenReturn(toMap);

--- a/androidsendgrid/src/test/res/json/email_content_html_empty
+++ b/androidsendgrid/src/test/res/json/email_content_html_empty
@@ -16,10 +16,6 @@
     {
       "type":"text/plain",
       "value":"Email content body"
-    },
-    {
-      "type":"text/html",
-      "value":" "
     }
   ]
 }

--- a/androidsendgrid/src/test/res/json/email_content_plain_empty
+++ b/androidsendgrid/src/test/res/json/email_content_plain_empty
@@ -14,10 +14,6 @@
   },
   "content":[
     {
-      "type":"text/plain",
-      "value":" "
-    },
-    {
       "type":"text/html",
       "value":"Email content body"
     }


### PR DESCRIPTION
Should not include html/text and plain/text mime types in the same mail even though the api says it can handle multiple different types at a time.